### PR TITLE
Make this repo work as a terraform module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ python
 *.tfstate*
 .terraform
 .terraform.lock.hcl
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -6,4 +6,12 @@ The `canvasLayer.zip` file is checked into version control, but version changes 
 
 ## Terraform
 
-This repo contains a sample terraform file meant to add the lambda layer to an AWS account.
+The `terraform` directory can be used as a terraform module from this git repository. The source should look something like this:
+
+```
+source: github.com/Harvard-ATG/canvas-access-lambda-layer//terraform
+```
+
+The `//` denotes the break between the address of the repository and the path to the terraform module within the repository. See the [Terraform documentation on sources](https://developer.hashicorp.com/terraform/language/modules/sources) for a full description of options in referencing module sources from a git repository.
+
+In my experience, you can safely include this module in multiple terraform configurations in the same account, and it will just add additional revisions as long as the layer name is the same.

--- a/buildLayer.sh
+++ b/buildLayer.sh
@@ -2,4 +2,4 @@
 pip install -r requirements.txt -t ./python
 
 # Zip dependencies into a file for use as a lambda layer
-zip -r canvasLayer.zip ./python/
+zip -r terraform/canvasLayer.zip ./python/

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 data "local_file" "lambda_layer" {
-  filename = "./canvasLayer.zip"
+  filename = "${path.module}/canvasLayer.zip"
 }
 
 resource "aws_lambda_layer_version" "canvas" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 data "local_file" "lambda_layer" {
-  filename = "../canvasLayer.zip"
+  filename = "./canvasLayer.zip"
 }
 
 resource "aws_lambda_layer_version" "canvas" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,3 +13,7 @@ resource "aws_lambda_layer_version" "canvas" {
 
   source_code_hash = data.local_file.lambda_layer.content_base64sha256
 }
+
+output "layer_name" {
+  value = aws_lambda_layer_version.canvas.layer_name
+}


### PR DESCRIPTION
This PR changes this repository to function as a terraform module that can be used directly from the repository. I've updated the README file to include notes on how to do that, and verified that it works using the dev environment for JupyterHub, referencing the working branch.

If this looks good, we should tag this as a 1.0 release on the repo and include that as a ref when using the module so that we can be explicit about updates. I think that will also help with pulling those updates without having to run `terraform init --upgrade`

This is a trial run for making a similar setup for a lambda layer for the JupyterHub reporting setup, so I want to make sure that this kind of pattern seems reasonable going forward. Ideally, we don't need to create new layers for different clusters or setups within the same account, but we do want to ensure that the layer exists within our IaC, so there are fewer things that we have to remember to do manually if we switch environments. Including this as a module in an environment seems safe, even when the layer already exists. When I applied a terraform config with this module to atood-dev, which already had this layer manually created, it just added a new layer revision that, as far as I can tell, is the same as it was before.